### PR TITLE
TS fix to comply with v4.8 and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "request-dot-js",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "author": "Kyle Bebak <kylebebak@gmail.com>",
   "description": "A ~1kB fetch wrapper with convenient error handling, automatic JSON transforms, and support for exponential backoff.",
   "keywords": [

--- a/server.ts
+++ b/server.ts
@@ -118,7 +118,7 @@ const request = (async <T = any, ET = any>(url: string, options?: Options<T, ET>
     if (status < 300) response = { ...fields, data, type: 'success' }
     else response = { ...fields, data, type: 'error' }
   } catch (e) {
-    response = { data: e, type: 'exception' }
+    response = { data: e as Error, type: 'exception' }
   }
 
   if (retry) {


### PR DESCRIPTION
Fix to comply with Typescript v4.8 and above.
This change fixes a TS error raised by this specific [breaking change](https://github.com/microsoft/TypeScript/wiki/Breaking-Changes#typescript-48)

We are not updating the TS version of this repo, but with this change, it will comply with recent TS versions while being compatible with the current TS version.